### PR TITLE
Replace mocks with API hooks

### DIFF
--- a/components/folder-tree.tsx
+++ b/components/folder-tree.tsx
@@ -5,10 +5,10 @@ import { ChevronRight, ChevronDown, Folder, FolderOpen, Plus, Users } from "luci
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { cn } from "@/lib/utils"
-import type { FolderItem } from "@/components/password-manager"
+import type { Folder } from "@/types/folder"
 
 interface FolderTreeProps {
-  folders: FolderItem[]
+  folders: Folder[]
   selectedFolderId: string | null
   onSelectFolder: (folderId: string | null) => void
   onAddFolder: (name: string, parentId: string | null) => void
@@ -38,7 +38,7 @@ export function FolderTree({ folders, selectedFolderId, onSelectFolder, onAddFol
     }
   }
 
-  const renderFolder = (folder: FolderItem, level = 0) => {
+  const renderFolder = (folder: Folder, level = 0) => {
     const isExpanded = expandedFolders[folder.id]
     const isSelected = selectedFolderId === folder.id
     const childFolders = folders.filter((f) => f.parentId === folder.id)

--- a/components/password-form.tsx
+++ b/components/password-form.tsx
@@ -22,12 +22,12 @@ import { Slider } from "@/components/ui/slider"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Textarea } from "@/components/ui/textarea"
-import type { FolderItem } from "@/components/password-manager"
+import type { Folder } from "@/types/folder"
 import { Switch } from "@/components/ui/switch"
 
 interface PasswordFormProps {
   onAddPassword: (password: any) => void
-  folders: FolderItem[]
+  folders: Folder[]
   onAddFolder: (name: string, parentId: string | null) => void
   onCancel: () => void
   allTags: string[]
@@ -236,7 +236,7 @@ export function PasswordForm({ onAddPassword, folders, onAddFolder, onCancel, al
   }
 
   // Get folder path for display
-  const getFolderPath = (folder: FolderItem): string => {
+  const getFolderPath = (folder: Folder): string => {
     if (!folder.parentId) return folder.name
 
     const parent = folders.find((f) => f.id === folder.parentId)

--- a/components/password-list.tsx
+++ b/components/password-list.tsx
@@ -14,7 +14,8 @@ import {
 } from "@/components/ui/dropdown-menu"
 import { Badge } from "@/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
-import type { FolderItem, PasswordEntry } from "@/components/password-manager"
+import type { Folder } from "@/types/folder"
+import type { PasswordEntry } from "@/types/password-entry"
 import {
   Dialog,
   DialogContent,
@@ -30,7 +31,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { getPasswordUsage, usePassword } from "@/lib/api/security"
 interface PasswordListProps {
   passwords: PasswordEntry[]
-  folders: FolderItem[]
+  folders: Folder[]
 }
 
 export function PasswordList({ passwords, folders }: PasswordListProps) {

--- a/hooks/use-credentials.ts
+++ b/hooks/use-credentials.ts
@@ -1,37 +1,47 @@
 import { useState, useEffect } from 'react'
-import { Credential } from '@/types/credential'
-import { mockCredentials } from '@/lib/mocks/credentials'
+import type { PasswordEntry } from '@/types/password-entry'
 
-export function useCredentials() {
-  const [credentials, setCredentials] = useState<Credential[]>([])
+function computeStrength(password: string): 'weak' | 'medium' | 'strong' {
+  if (password.length > 12 && /[A-Z]/.test(password) && /[^A-Za-z0-9]/.test(password)) return 'strong'
+  if (password.length >= 8) return 'medium'
+  return 'weak'
+}
+
+export function useCredentials(userId: string) {
+  const [credentials, setCredentials] = useState<PasswordEntry[]>([])
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
-    const fetchCredentials = async () => {
+    async function fetchCredentials() {
       try {
-        // En développement, utiliser les données mockées
-        if (process.env.NODE_ENV === 'development') {
-          setCredentials(mockCredentials)
-          setIsLoading(false)
-          return
-        }
-
-        // En production, faire l'appel API
-        const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/credentials`)
-        if (!response.ok) {
+        const url = new URL(`${process.env.NEXT_PUBLIC_API_URL}/users/credentials`)
+        url.searchParams.append('user_id', userId)
+        const res = await fetch(url.toString(), { cache: 'no-store' })
+        if (!res.ok) {
           throw new Error('Erreur lors de la récupération des credentials')
         }
-        const data = await response.json()
-        setCredentials(data)
-      } catch (error) {
-        console.error('Erreur:', error)
+        const data = await res.json()
+        const mapped = data.map((c: any) => ({
+          id: c.id,
+          title: c.title,
+          website: c.domain_name,
+          username: c.user_identifier,
+          password: c.password,
+          strength: computeStrength(c.password ?? ''),
+          lastUpdated: c.updated_at ?? c.created_at,
+          folderId: '',
+          tags: [],
+        }))
+        setCredentials(mapped)
+      } catch (err) {
+        console.error(err)
       } finally {
         setIsLoading(false)
       }
     }
 
     fetchCredentials()
-  }, [])
+  }, [userId])
 
   return { credentials, isLoading }
-} 
+}

--- a/hooks/use-folders.ts
+++ b/hooks/use-folders.ts
@@ -1,0 +1,35 @@
+import { useState, useEffect } from 'react'
+import type { Folder } from '@/types/folder'
+
+export function useFolders(userId: string) {
+  const [folders, setFolders] = useState<Folder[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetchFolders() {
+      try {
+        const url = new URL(`${process.env.NEXT_PUBLIC_API_URL}/folders`)
+        url.searchParams.append('user_id', userId)
+        const res = await fetch(url.toString(), { cache: 'no-store' })
+        if (!res.ok) {
+          throw new Error('Erreur lors de la récupération des dossiers')
+        }
+        const data = await res.json()
+        const mapped = data.folders.map((f: any) => ({
+          id: f.Id,
+          name: f.Name,
+          parentId: f.ParentID,
+        }))
+        setFolders(mapped)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchFolders()
+  }, [userId])
+
+  return { folders, isLoading }
+}

--- a/hooks/use-tags.ts
+++ b/hooks/use-tags.ts
@@ -1,0 +1,37 @@
+import { useState, useEffect } from 'react'
+import type { Tag } from '@/types/tag'
+
+export function useTags() {
+  const [tags, setTags] = useState<Tag[]>([])
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    async function fetchTags() {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/tags`, { cache: 'no-store' })
+        if (!res.ok) {
+          throw new Error('Erreur lors de la récupération des tags')
+        }
+        const data = await res.json()
+        const mapped = data.map((t: any) => ({
+          id: t.id,
+          name: t.name,
+          color: t.color,
+          folderId: t.folder_id,
+          createdBy: t.created_by,
+          createdAt: t.created_at,
+          updatedAt: t.updated_at,
+        }))
+        setTags(mapped)
+      } catch (err) {
+        console.error(err)
+      } finally {
+        setIsLoading(false)
+      }
+    }
+
+    fetchTags()
+  }, [])
+
+  return { tags, isLoading }
+}

--- a/types/folder.ts
+++ b/types/folder.ts
@@ -1,0 +1,6 @@
+export interface Folder {
+  id: string
+  name: string
+  parentId: string | null
+  shared?: boolean
+}

--- a/types/password-entry.ts
+++ b/types/password-entry.ts
@@ -1,0 +1,17 @@
+export interface PasswordEntry {
+  id: string
+  title: string
+  website: string
+  username: string
+  password: string
+  strength: "weak" | "medium" | "strong"
+  lastUpdated: string
+  folderId: string
+  tags: string[]
+  notes?: string
+  customFields?: { label: string; value: string; type: string }[]
+  files?: { name: string; size: number; type: string }[]
+  breached?: boolean
+  reused?: boolean
+  old?: boolean
+}

--- a/types/tag.ts
+++ b/types/tag.ts
@@ -1,0 +1,9 @@
+export interface Tag {
+  id: string
+  name: string
+  color: string
+  folderId: string
+  createdBy: string
+  createdAt: string
+  updatedAt: string
+}


### PR DESCRIPTION
## Summary
- add folders, tags, and password entry types
- create hooks to fetch folders, tags, and credentials from the API
- use the hooks in the password manager and related components
- update components to reference new types

## Testing
- `npm run lint` *(fails: prompts interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_684b35fd0b988324b28fe96dd9c81aa9

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces mock data with API-driven hooks for credentials, folders, and tags, and updates password manager/components to use new typed models.
> 
> - **Data layer**:
>   - **New types**: `types/folder`, `types/password-entry`, `types/tag`.
>   - **New hooks**: `use-credentials(userId)` (maps API payload, computes `strength`), `use-folders(userId)`, `use-tags()` fetching from `${NEXT_PUBLIC_API_URL}`.
> - **Password Manager** (`components/password-manager.tsx`):
>   - Removes inline mocks; loads data via new hooks with loading state; syncs into local state via `useEffect`.
>   - Preserves filtering, folder path, add password/folder, and tag selection.
> - **Components updated to new types**:
>   - `components/folder-tree.tsx`: props/types switched to `Folder`.
>   - `components/password-form.tsx`: uses `Folder` and `allTags`; folder path helper adjusted.
>   - `components/password-list.tsx`: uses `Folder` and `PasswordEntry`; integrates `getPasswordUsage`/`usePassword` for view/copy actions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 91183d4aec685c3b8bdf186356449b9171aa6a67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->